### PR TITLE
move to index 1 if container has pages

### DIFF
--- a/targetbot/looting.lua
+++ b/targetbot/looting.lua
@@ -281,7 +281,11 @@ TargetBot.Looting.lootItem = function(lootContainers, item)
   end
 
   local container = lootContainers[1]
-  g_game.move(item, container:getSlotPosition(container:getItemsCount()), 1)
+  if container:hasPages() then
+    g_game.move(item, container:getSlotPosition(1), 1)
+  else
+    g_game.move(item, container:getSlotPosition(container:getItemsCount()), 1)
+  end
   waitTill = now + 300 -- give it 0.3s to move item
 end
 

--- a/targetbot/looting.lua
+++ b/targetbot/looting.lua
@@ -175,7 +175,9 @@ TargetBot.Looting.getLootContainers = function(containers)
   for index, container in pairs(containers) do
     openedContainersById[container:getContainerItem():getId()] = 1
     if containersById[container:getContainerItem():getId()] and not container.lootContainer then
-      if container:getItemsCount() < container:getCapacity() or container:hasPages() then
+      if container:hasPages() then
+        table.insert(lootContainers, container)
+      elseif container:getItemsCount() < container:getCapacity() or container:hasPages() then
         table.insert(lootContainers, container)
       else -- it's full, open next container if possible
         for slot, item in ipairs(container:getItems()) do


### PR DESCRIPTION
I was running into a problem with looting into containers that are paged/infinite space. Lazily just placed move into to first slot and it worked.