### PR TITLE
support "Mage" vocation

### DIFF
--- a/vBot/extras.lua
+++ b/vBot/extras.lua
@@ -570,7 +570,7 @@ if true then
           guild = guild.."..."
         end
         local voc
-        if text:lower():find("sorcerer") then
+        if text:lower():find("sorcerer") or text:lower():find("mage") then
             voc = "MS"
         elseif text:lower():find("druid") then
             voc = "ED"


### PR DESCRIPTION
several OT servers merge MS/ED vocation into a Mage vocation having the best features of both MS and ED.

Without  this fix, on those servers, vBot would constantly error out with 
`Error: (...) concatenat voc: a nil value`