### PR TITLE
looting blacklist

### DIFF
--- a/targetbot/looting.lua
+++ b/targetbot/looting.lua
@@ -224,7 +224,7 @@ TargetBot.Looting.lootContainer = function(lootContainers, container)
   for i, item in ipairs(container:getItems()) do
     if item:isContainer() and not itemsById[item:getId()] then
       nextContainer = item
-    elseif itemsById[item:getId()] or (ui.everyItem:isOn() and not item:isContainer()) then
+    elseif (not ui.everyItem:isOn() and itemsById[item:getId()]) or (ui.everyItem:isOn() and (not item:isContainer() and not itemsById[item:getId()])) then    
       item.lootTries = (item.lootTries or 0) + 1
       if item.lootTries < 5 then -- if can't be looted within 0.5s then skip it
         return TargetBot.Looting.lootItem(lootContainers, item)

--- a/targetbot/looting.otui
+++ b/targetbot/looting.otui
@@ -17,7 +17,7 @@ TargetBotLootingPanel < Panel
   
   BotSwitch
     id: everyItem
-    !text: tr("Loot every item")
+    !text: tr("Loot every item, except these")
     margin-top: 2
 
   Label


### PR DESCRIPTION
When "loot every item" is off, it will loot everything in the loot list.

When "loot every item" is on, it will loot everything that is *not* in the loot list, effectively making the loot list a blacklist when "loot every item" is on.

resolves https://github.com/Vithrax/vBot/issues/15